### PR TITLE
PR for issue #5 Make constants in Takeaway\Takeaway configurable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Unofficial Takeaway.com API implementation",
     "type": "library",
     "require": {
+        "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3"
     },
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56b5d62283b7c0a0f25ab92f0f6c4670",
+    "content-hash": "2e41644bcccf73d2cda42a7f5b651313",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -244,6 +244,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.1"
+    },
     "platform-dev": []
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -56,7 +56,7 @@ class Client
     public function request($body)
     {
         try {
-            $response = $this->client->request('POST', Takeaway::BASE_URL, [
+            $response = $this->client->request('POST', Takeaway::getConfigValue(Takeaway::CFG_BASE_URL), [
                 'headers' => [
                     'Content-Type' => 'application/x-www-form-urlencoded;charset=UTF-8',
                 ],

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -56,14 +56,14 @@ class Request
             $body .= '&var'.($index + 1).'='.($value);
         }
 
-        $md5 = md5($md5.Takeaway::PASSWORD);
+        $md5 = md5($md5.Takeaway::getConfigValue(Takeaway::CFG_PASSWORD));
 
         $body = 'var0='.$md5.$body;
 
-        $body .= '&version='.Takeaway::VERSION;
-        $body .= '&systemversion='.Takeaway::SYSTEM_VERSION;
-        $body .= '&appname='.Takeaway::APP_NAME;
-        $body .= '&language='.Takeaway::LANGUAGE;
+        $body .= '&version='.Takeaway::getConfigValue(Takeaway::CFG_VERSION);
+        $body .= '&systemversion='.Takeaway::getConfigValue(Takeaway::CFG_SYSTEM_VERSION);
+        $body .= '&appname='.Takeaway::getConfigValue(Takeaway::CFG_APP_NAME);
+        $body .= '&language='.Takeaway::getConfigValue(Takeaway::CFG_LANGUAGE);
 
         return $body;
     }

--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -33,7 +33,7 @@ class Country extends Model
     public function getRestaurants($postalCode, $latitude, $longitude)
     {
         return (new GetRestaurantsRequest(
-            $postalCode, $this->countryCode, $latitude, $longitude, Takeaway::LANGUAGE
+            $postalCode, $this->countryCode, $latitude, $longitude, Takeaway::getConfigValue(Takeaway::CFG_LANGUAGE)
         ))->getData()['restaurants'];
     }
 }

--- a/src/Takeaway.php
+++ b/src/Takeaway.php
@@ -2,9 +2,6 @@
 
 namespace Takeaway;
 
-use Takeaway\Models\Country;
-use Takeaway\Models\Restaurant;
-use Takeaway\Traits\MakesRequests;
 use Takeaway\Http\Requests\GetCountriesRequest;
 
 class Takeaway

--- a/src/Takeaway.php
+++ b/src/Takeaway.php
@@ -9,13 +9,43 @@ use Takeaway\Http\Requests\GetCountriesRequest;
 
 class Takeaway
 {
-    public const BASE_URL = 'https://nl.citymeal.com/android/android.php';
-    public const LANGUAGE = 'nl';
-    public const PASSWORD = '4ndro1d';
-    public const VERSION = '5.7';
-    public const SYSTEM_VERSION = '24';
-    public const APP_VERSION = '4.15.3.2';
-    public const APP_NAME = 'Takeaway.com';
+
+    public const CFG_BASE_URL       = 'BASE_URL';
+    public const CFG_LANGUAGE       = 'LANGUAGE';
+    public const CFG_PASSWORD       = 'PASSWORD';
+    public const CFG_VERSION        = 'VERSION';
+    public const CFG_SYSTEM_VERSION = 'SYSTEM_VERSION';
+    public const CFG_APP_VERSION    = 'APP_VERSION';
+    public const CFG_APP_NAME       = 'APP_NAME';
+
+    protected static $configuration = [
+        self::CFG_BASE_URL       => 'https://nl.citymeal.com/android/android.php',
+        self::CFG_LANGUAGE       => 'nl',
+        self::CFG_PASSWORD       => '4ndro1d',
+        self::CFG_VERSION        => '5.7',
+        self::CFG_SYSTEM_VERSION => '24',
+        self::CFG_APP_VERSION    => '4.15.3.2',
+        self::CFG_APP_NAME       => 'Takeaway.com',
+    ];
+
+    /**
+     * Configures the TakeAway class.
+     * @param array $config configuration values, key is one of the CFG_* constants, value is the new setting
+     */
+    public static function configure($config): void
+    {
+        static::$configuration = array_merge(static::$configuration, $config);
+    }
+
+    /**
+     * Get a configuration value
+     * @param string $name one of the CFG_* constants
+     * @return string configuration value
+     */
+    public static function getConfigValue($name): string
+    {
+        return static::$configuration[$name] ?? '';
+    }
 
     public static function getCountries()
     {


### PR DESCRIPTION
Here is the PR to make the constants configurable (as described in #5). Calling `Takeaway::configure([Takeaway::CFG_LANGUAGE => 'de'])` will update the config and set the language to German for example. The language configuration value is retrieved by calling `Takeaway::getConfigValue(Takeaway::CFG_LANGUAGE)`